### PR TITLE
Upgrade to .Net 6

### DIFF
--- a/src/FunctionsValidationFilter.DependencyInjection/FunctionsValidationFilter.DependencyInjection.csproj
+++ b/src/FunctionsValidationFilter.DependencyInjection/FunctionsValidationFilter.DependencyInjection.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FunctionsValidationFilter/FunctionsValidationFilter.csproj
+++ b/src/FunctionsValidationFilter/FunctionsValidationFilter.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="1.4.0" />
   </ItemGroup>
 

--- a/test/FunctionsValidationFilter.Tests/FunctionsValidationFilter.Tests.csproj
+++ b/test/FunctionsValidationFilter.Tests/FunctionsValidationFilter.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221003-04" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/test/FunctionsValidationFilter.Tests/FunctionsValidationFilter.Tests.csproj
+++ b/test/FunctionsValidationFilter.Tests/FunctionsValidationFilter.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221003-04" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/FunctionsValidationFilter.Tests/ValidatorInspectorTest.cs
+++ b/test/FunctionsValidationFilter.Tests/ValidatorInspectorTest.cs
@@ -21,7 +21,7 @@ public class ValidatorInspectorTest
         var result = ValidatorInspector.TryGetRules(typeof(SampleValidator), out var _, out var rules);
 
         Assert.True(result);
-        var rule = Assert.Single(rules);
+        var rule = Assert.Single(rules!);
         Assert.Equal("MyProperty", rule.PropertyName);
         var component = Assert.Single(rule.Components);
         Assert.IsType<NotEmptyValidator<Sample, string>>(component.Validator);

--- a/test/FunctionsValidationFilter.Tests/ValidatorMapperTest.cs
+++ b/test/FunctionsValidationFilter.Tests/ValidatorMapperTest.cs
@@ -195,7 +195,7 @@ public class ValidatorMapperTest
     public void ScalePrecisionRule()
     {
         // Arrange
-        var component = CreateDecimalComponent(x => x.ScalePrecision(2, 6));
+        var component = CreateDecimalComponent(x => x.PrecisionScale(6, 2, true));
 
         // Act
         _mapper.TryMap(component, out var result);


### PR DESCRIPTION
This PR Upgrades to .Net 6 and is essential for the upgrade of Unified API to .Net 6 as without this upgrade the Open API generation fails.